### PR TITLE
Fix notify when blocking peers that are not publishing

### DIFF
--- a/config.js
+++ b/config.js
@@ -32,7 +32,7 @@ const config =
 	{
 		listenIp   : '0.0.0.0',
 		// NOTE: Don't change listenPort (client app assumes 4443).
-		listenPort : process.env.ADMIN_LISTEN_PORT || 4443
+		listenPort : process.env.ADMIN_LISTEN_PORT || 7000
 	},
 	// mediasoup settings.
 	mediasoup :

--- a/lib/Room.js
+++ b/lib/Room.js
@@ -1440,19 +1440,20 @@ class Room extends EventEmitter
 				const localConsumerId = localPeer.data.peerIdToConsumerId.get(remotePeerId);
 				const localConsumer = localPeer.data.consumers.get(localConsumerId);
 				if (localConsumer) {
-					localPeer.data.blockedPeers.add(remotePeerId);
 					localConsumer.pause();
+				}
+
+				localPeer.data.blockedPeers.add(remotePeerId);
 					
-					if (this._protooRoom.hasPeer(remotePeerId)) {
-						const remotePeer = this._protooRoom.getPeer(remotePeerId)
-						const remoteConsumerId = remotePeer.data.peerIdToConsumerId.get(localPeer.id);
-						const remoteConsumer = remotePeer.data.consumers.get(remoteConsumerId);
-						if(remoteConsumer) {
-							remoteConsumer.pause();
-							remotePeer.notify('peerBlocked', { peerId: localPeer.id }).catch(() => {});
-						}
+				if (this._protooRoom.hasPeer(remotePeerId)) {
+					const remotePeer = this._protooRoom.getPeer(remotePeerId)
+					const remoteConsumerId = remotePeer.data.peerIdToConsumerId.get(localPeer.id);
+					const remoteConsumer = remotePeer.data.consumers.get(remoteConsumerId);
+					if(remoteConsumer) {
+						remoteConsumer.pause();
 					}
-				}	
+					remotePeer.notify('peerBlocked', { peerId: localPeer.id }).catch(() => {});
+				}
 				accept();
 				break;
 			}


### PR DESCRIPTION
fix issue preventing peers that are not publishing from being notified of a block.
update default ADMIN_LISTEN_PORT to use a different port than the PROTOO_LISTEN_PORT.