### PR TITLE
restart the dialog server if the cert file is updated

### DIFF
--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -35,7 +35,7 @@ export PROTOO_LISTEN_PORT={{ cfg.transports.websockets.wss_port }}
 export ADMIN_LISTEN_PORT={{ cfg.transports.http.admin_port }}
 
 (
-  OLD_PRIVKEY=$(<$1)
+  OLD_PRIVKEY=$(cat $HTTPS_CERT_PRIVKEY)
   while true
   do 
     if ! diff <(cat $HTTPS_CERT_PRIVKEY) <(echo $OLD_PRIVKEY) >/dev/null 2>&1; then

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -35,10 +35,10 @@ export PROTOO_LISTEN_PORT={{ cfg.transports.websockets.wss_port }}
 export ADMIN_LISTEN_PORT={{ cfg.transports.http.admin_port }}
 
 (
-  OLD_PRIVKEY=$(cat $HTTPS_CERT_PRIVKEY)
+  OLD_PRIVKEY=$(cat "$HTTPS_CERT_PRIVKEY")
   while true
   do 
-    if ! diff <(cat $HTTPS_CERT_PRIVKEY) <(echo $OLD_PRIVKEY) >/dev/null 2>&1; then
+    if ! diff <(cat "$HTTPS_CERT_PRIVKEY") <(echo "$OLD_PRIVKEY") >/dev/null 2>&1; then
       echo "New SSL Cert detected; restarting Dialog process"
       kill $$
       break

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -34,14 +34,13 @@ export MEDIASOUP_LISTEN_IP={{ cfg.transports.http.admin_ip }}
 export PROTOO_LISTEN_PORT={{ cfg.transports.websockets.wss_port }}
 export ADMIN_LISTEN_PORT={{ cfg.transports.http.admin_port }}
 
-OLD_PRIVKEY=wss.key.old
-cp $HTTPS_CERT_PRIVKEY $OLD_PRIVKEY
-
 (
+  OLD_PRIVKEY=$(<$1)
   while true
   do 
-    if ! diff "$HTTPS_CERT_PRIVKEY" "$OLD_PRIVKEY" >/dev/null 2>&1; then
-      pkill "dialog"
+    if ! diff <(cat $HTTPS_CERT_PRIVKEY) <(echo $OLD_PRIVKEY) >/dev/null 2>&1; then
+      echo "New SSL Cert detected; restarting Dialog process"
+      kill $$
       break
     fi
     sleep 3600

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -21,7 +21,7 @@ if [[ -z "$MEDIASOUP_ANNOUNCED_IP" ]] ; then
   MEDIASOUP_ANNOUNCED_IP=$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n1)
 fi
 
-# C onvert legacy der file
+# Convert legacy der file
 if [[ ! -f "{{ pkg.svc_files_path }}/perms.pub.pem" ]] ; then
   openssl rsa -in {{ pkg.svc_files_path }}/perms.pub.der -inform DER -RSAPublicKey_in -out {{ pkg.svc_files_path }}/perms.pub.pem
 fi

--- a/habitat/hooks/run
+++ b/habitat/hooks/run
@@ -21,7 +21,7 @@ if [[ -z "$MEDIASOUP_ANNOUNCED_IP" ]] ; then
   MEDIASOUP_ANNOUNCED_IP=$(ip -4 addr show eth0 | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n1)
 fi
 
-# Convert legacy der file
+# C onvert legacy der file
 if [[ ! -f "{{ pkg.svc_files_path }}/perms.pub.pem" ]] ; then
   openssl rsa -in {{ pkg.svc_files_path }}/perms.pub.der -inform DER -RSAPublicKey_in -out {{ pkg.svc_files_path }}/perms.pub.pem
 fi
@@ -33,4 +33,19 @@ export AUTH_KEY={{ pkg.svc_files_path }}/perms.pub.pem
 export MEDIASOUP_LISTEN_IP={{ cfg.transports.http.admin_ip }}
 export PROTOO_LISTEN_PORT={{ cfg.transports.websockets.wss_port }}
 export ADMIN_LISTEN_PORT={{ cfg.transports.http.admin_port }}
+
+OLD_PRIVKEY=wss.key.old
+cp $HTTPS_CERT_PRIVKEY $OLD_PRIVKEY
+
+(
+  while true
+  do 
+    if ! diff "$HTTPS_CERT_PRIVKEY" "$OLD_PRIVKEY" >/dev/null 2>&1; then
+      pkill "dialog"
+      break
+    fi
+    sleep 3600
+  done
+)
+
 exec node {{ pkg.path }}/index.js


### PR DESCRIPTION
Adds a subshell loop in `run` that checks to see if the cert file has been updated. If so, it kills the dialog process allowing the hab supervisor to restart it and fetch the new cert.