### PR TITLE
Mediasoup bump to match the client version

### DIFF
--- a/lib/interactiveClient.js
+++ b/lib/interactiveClient.js
@@ -12,8 +12,12 @@ module.exports = async function()
 
 	process.stdin.pipe(socket);
 	socket.pipe(process.stdout);
-
-	socket.on('connect', () => process.stdin.setRawMode(true));
+		
+	socket.on('connect', () => {
+		if (process.stdin.isTTY) {
+			process.stdin.setRawMode(true);
+		}
+	});
 	socket.on('close', () => process.exit(0));
 	socket.on('exit', () => socket.end());
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -119,6 +119,7 @@
       "version": "6.12.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
       "integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -237,9 +238,9 @@
       "optional": true
     },
     "aws4": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-      "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+      "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
       "optional": true
     },
     "balanced-match": {
@@ -1610,13 +1611,27 @@
       "optional": true
     },
     "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+      "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
       "optional": true,
       "requires": {
-        "ajv": "^6.5.5",
+        "ajv": "^6.12.3",
         "har-schema": "^2.0.0"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "6.12.6",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+          "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+          "optional": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
+          }
+        }
       }
     },
     "has-ansi": {
@@ -2439,29 +2454,53 @@
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "mediasoup": {
-      "version": "github:versatica/mediasoup#22d5d18d9b676f276cf1cff055d2c51ca2784ac4",
-      "from": "github:versatica/mediasoup#v3",
+      "version": "3.6.24",
+      "resolved": "https://registry.npmjs.org/mediasoup/-/mediasoup-3.6.24.tgz",
+      "integrity": "sha512-H14/CNhiKsxxlkPZSV1R12FN+3eoy5zEARV6BJhC/60z9058wrDy4gy+9NsZ+R3DNeBWIeOpu6lHfdCKdq8QqA==",
       "requires": {
-        "@types/node": "^14.0.5",
-        "awaitqueue": "^2.1.1",
+        "@types/node": "^14.11.10",
+        "awaitqueue": "^2.3.1",
         "clang-tools-prebuilt": "^0.1.4",
-        "debug": "^4.1.1",
+        "debug": "^4.2.0",
         "h264-profile-level-id": "^1.0.1",
         "netstring": "^0.3.0",
         "random-number": "^0.0.9",
-        "supports-color": "^7.1.0",
-        "uuid": "^8.1.0"
+        "supports-color": "^7.2.0",
+        "uuid": "^8.3.1"
       },
       "dependencies": {
+        "@types/node": {
+          "version": "14.14.6",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+          "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
+        },
+        "awaitqueue": {
+          "version": "2.3.3",
+          "resolved": "https://registry.npmjs.org/awaitqueue/-/awaitqueue-2.3.3.tgz",
+          "integrity": "sha512-RbzQg6VtPUtyErm55iuQLTrBJ2uihy5BKBOEkyBwv67xm5Fn2o/j+Bz+a5BmfSoe2oZ5dcz9Z3fExS8pL+LLhw=="
+        },
+        "debug": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -4312,9 +4351,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.1.0.tgz",
-      "integrity": "sha512-CI18flHDznR0lq54xBycOVmphdCYnQLKn8abKn7PXUiKUGdEd+/l9LWNJmugXel4hXq7S+RMNl34ecyC9TntWg=="
+      "version": "8.3.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+      "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "express": "^4.17.1",
     "heapdump": "^0.3.15",
     "jsonwebtoken": "^8.5.1",
-    "mediasoup": "github:versatica/mediasoup#v3",
+    "mediasoup": "^3.6.24",
     "pidusage": "^2.0.18",
     "protoo-server": "^4.0.4",
     "sctp": "^0.0.19"


### PR DESCRIPTION
Bump the Mediasoup server side libs to match the once updated in the client https://github.com/mozilla/hubs/pull/3305

*Note: This PR shoul dbe merged a the same time as https://github.com/mozilla/hubs/pull/3305*