### PR TITLE
Support for getting peers and closing transports

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,7 +1,7 @@
 pkg_name=janus-gateway
 pkg_origin=mozillareality
 pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
-pkg_version="2.0.0"
+pkg_version="2.0.1"
 pkg_description="A simple mediasoup based SFU"
 
 pkg_deps=(

--- a/lib/Room.js
+++ b/lib/Room.js
@@ -690,6 +690,44 @@ class Room extends EventEmitter
 		});
 	}
 
+	async _consumeExistingProducers(peer, joinedPeers) {
+		for (const joinedPeer of joinedPeers)
+		{
+			// Create Consumers for existing Producers.
+			for (const producer of joinedPeer.data.producers.values())
+			{
+				await this._createConsumer(
+					{
+						consumerPeer : peer,
+						producerPeer : joinedPeer,
+						producer
+					});
+			}
+
+			// Create DataConsumers for existing DataProducers.
+			for (const dataProducer of joinedPeer.data.dataProducers.values())
+			{
+				if (dataProducer.label === 'bot')
+					continue;
+
+				await this._createDataConsumer(
+					{
+						dataConsumerPeer : peer,
+						dataProducerPeer : joinedPeer,
+						dataProducer
+					});
+			}
+		}
+
+		// Create DataConsumers for bot DataProducer.
+		await this._createDataConsumer(
+			{
+				dataConsumerPeer : peer,
+				dataProducerPeer : null,
+				dataProducer     : this._bot.dataProducer
+			});
+	}
+
 	/**
 	 * Handle protoo requests from browsers.
 	 *
@@ -764,41 +802,7 @@ class Room extends EventEmitter
 				// Mark the new Peer as joined.
 				peer.data.joined = true;
 
-				for (const joinedPeer of joinedPeers)
-				{
-					// Create Consumers for existing Producers.
-					for (const producer of joinedPeer.data.producers.values())
-					{
-						this._createConsumer(
-							{
-								consumerPeer : peer,
-								producerPeer : joinedPeer,
-								producer
-							});
-					}
-
-					// Create DataConsumers for existing DataProducers.
-					for (const dataProducer of joinedPeer.data.dataProducers.values())
-					{
-						if (dataProducer.label === 'bot')
-							continue;
-
-						this._createDataConsumer(
-							{
-								dataConsumerPeer : peer,
-								dataProducerPeer : joinedPeer,
-								dataProducer
-							});
-					}
-				}
-
-				// Create DataConsumers for bot DataProducer.
-				this._createDataConsumer(
-					{
-						dataConsumerPeer : peer,
-						dataProducerPeer : null,
-						dataProducer     : this._bot.dataProducer
-					});
+				await this._consumeExistingProducers(peer, joinedPeers);
 
 				// Notify the new Peer to all other Peers.
 				for (const otherPeer of this._getJoinedPeers({ excludePeer: peer }))
@@ -812,6 +816,25 @@ class Room extends EventEmitter
 						})
 						.catch(() => {});
 				}
+
+				break;
+			}
+
+			case 'refreshConsumers':
+			{
+				// Ensure the Peer is already joined.
+				if (!peer.data.joined)
+					throw new Error('Peer not joined');
+
+				accept();
+
+				const joinedPeers =
+				[
+					...this._getJoinedPeers({ excludePeer: peer }),
+					...this._broadcasters.values()
+				];
+
+				await this._consumeExistingProducers(peer, joinedPeers);
 
 				break;
 			}
@@ -882,6 +905,10 @@ class Room extends EventEmitter
 				// Store the WebRtcTransport into the protoo Peer data Object.
 				peer.data.transports.set(transport.id, transport);
 
+				transport.observer.on('close', () => {
+					peer.data.transports.delete(transport.id);
+				});
+
 				accept(
 					{
 						id             : transport.id,
@@ -899,6 +926,20 @@ class Room extends EventEmitter
 					try { await transport.setMaxIncomingBitrate(maxIncomingBitrate); }
 					catch (error) {}
 				}
+
+				break;
+			}
+
+			case 'closeWebRtcTransport': {
+				const { transportId } = request.data;
+				const transport = peer.data.transports.get(transportId);
+
+				if (!transport)
+					throw new Error(`transport with id "${transportId}" not found`);
+
+				transport.close();
+
+				accept();
 
 				break;
 			}


### PR DESCRIPTION
This PR adds support for closing transports from a client and getting the other peers consumers. This is used int he hubs client to recreate transports and consumers/producers when we need to recover from a ICE failure.

Related https://github.com/mozilla/hubs/pull/3930