### PR TITLE
gha-update

### DIFF
--- a/.github/workflows/dialog.yml
+++ b/.github/workflows/dialog.yml
@@ -51,7 +51,7 @@ jobs:
           docker pull $fromTag && docker tag $fromTag $toTag && sudo docker push $toTag
       - name: promote artifact
         run: |
-          fromTag=${{ env.registryName }}/${{ env.containerName }}:${{ github.run_number }}
+          fromTag=${{ env.registryName }}/${{ env.containerName }}:${GITHUB_SHA::7}
           toTag=${{ env.registryName }}/${{ env.containerName }}:${GITHUB_REF/'refs/heads/'/}
           toTag=${toTag//:master/:dev}
           echo "promoting :$fromTag to :$toTag"

--- a/.github/workflows/dialog.yml
+++ b/.github/workflows/dialog.yml
@@ -10,6 +10,7 @@ env:
 
 jobs:
   build:
+    if: github.ref != 'refs/heads/staging' || github.ref != 'refs/heads/prod'
     runs-on: ubuntu-latest
     steps:
       - name: checkout-dialog
@@ -40,10 +41,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
+      - name: master branch -- produce commit-sha tagged image
+        if: github.ref == 'refs/heads/master'
+        run: |
+          fromTag=${{ env.registryName }}/${{ env.containerName }}:${{ github.run_number }}
+          toTag=${{ env.registryName }}/${{ env.containerName }}:${GITHUB_SHA::7}
+          echo "promoting :$fromTag to :$toTag"
+          echo ${{ secrets.DOCKER_HUB_PWD }} | sudo docker login --username $registryName --password-stdin
+          docker pull $fromTag && docker tag $fromTag $toTag && sudo docker push $toTag
       - name: promote artifact
         run: |
           fromTag=${{ env.registryName }}/${{ env.containerName }}:${{ github.run_number }}
-          toTag=${{ env.registryName }}/${{ env.containerName }}:${GITHUB_REF/'refs/heads/'/}          
+          toTag=${{ env.registryName }}/${{ env.containerName }}:${GITHUB_REF/'refs/heads/'/}
           toTag=${toTag//:master/:dev}
           echo "promoting :$fromTag to :$toTag"
           echo ${{ secrets.DOCKER_HUB_PWD }} | sudo docker login --username $registryName --password-stdin


### PR DESCRIPTION
changes to gha workflow:
- build stage ignores staging and prod branches
- promote stage: push to master branch in addition produces ${commitSha::7} tagged container image
- promote stage: now promote from ${commitSha::7} tag instead of ${github.run_number} tag

effects:
- promotes above master/dev environment does not rebuild artifact (container image)
- PRs to staging and dev must merge with fast-forward (aka. rebase and merge in github)