### PR TITLE
Avoid installing newer versions of mediasoup

### DIFF
--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -18,7 +18,6 @@ pkg_build_deps=(
 )
 
 do_build() {
-  npm install mediasoup
   CFLAGS="${CFLAGS} -O2 -g" CPPFLAGS="${CPPFLAGS} -O2 -g" CXXFLAGS="${CXXFLAGS} -O2 -g" npm ci
   patchelf --set-rpath "$(pkg_path_for gcc-libs)/lib" node_modules/mediasoup/worker/out/Release/mediasoup-worker
   pushd node_modules


### PR DESCRIPTION
Not sure why we ever had this line in here. It seems wrong that we would want to install the latest version of mediasoup during the habitat build. It also resulted in the build failing due to other dependency mismatches. We should be relying on the version specified in package.json and package-lock.json instead, which is handled by `npm ci`.