### PR TITLE
Pin Node to v18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-from node:lts as build
+# syntax=docker/dockerfile:1
+ARG NODE_VERSION=18
+
+FROM node:${NODE_VERSION} AS build
 workdir /app
 run apt-get update > /dev/null && apt-get -y install python3-pip > /dev/null
 run mkdir certs && openssl req -x509 -newkey rsa:2048 -sha256 -days 36500 -nodes -keyout certs/privkey.pem -out certs/fullchain.pem -subj '/CN=dialog'

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -5,7 +5,7 @@ pkg_version="2.0.1"
 pkg_description="A simple mediasoup based SFU"
 
 pkg_deps=(
-  core/node/12.9.0
+  core/node/18
   mozillareality/gcc-libs
   mozillareality/openssl
 )


### PR DESCRIPTION
Why
---
This is the current Long Term Support (LTS) version of Node.  Pinning gives us a degree of reproducibility.  Pinning only the major version gives us minor upgrades and security patches through at least 2025-04-30.