### PR TITLE
Fixes mozilla/dialog#53

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,6 +93,7 @@ async function runMediasoupWorkers()
 				rtcMinPort : Number(config.mediasoup.workerSettings.rtcMinPort),
 				rtcMaxPort : Number(config.mediasoup.workerSettings.rtcMaxPort)
 			});
+		worker._pid = i;
 
 		worker.on('died', () =>
 		{

--- a/lib/Room.js
+++ b/lib/Room.js
@@ -1488,15 +1488,14 @@ class Room extends EventEmitter
 		for (const peer of peersToPipe)
 		{
 			const srcRouter = this._mediasoupRouters.get(peer.data.routerId);
+			if (routerId === peer.data.routerId)
+			{
+				logger.info("~~~skipping~parenting~router~~~")
+				continue;
+			}
 
 			for (const producerId of peer.data.producers.keys())
 			{
-				if (router._producers.has(producerId))
-				{
-					logger.info("~~~skipping~parenting~router~~~")
-					continue;
-				}
-
 				await srcRouter.pipeToRouter({
 					producerId : producerId,
 					router     : router


### PR DESCRIPTION
Fixes mozilla/dialog#53
- Add `_pid`s to workers
- Fix `router._producers.has(producerId)` throwing errors.