### PR TITLE
[Mozilla Branding Removal] Removing branding

### DIFF
--- a/.github/workflows/dialog.yml
+++ b/.github/workflows/dialog.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   turkeyGitops:
-    uses: Hubs-Foudation/hubs-ops/.github/workflows/turkeyGitops.yml@master
+    uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
       registry: Hubs-Foundation
       dockerfile: Dockerfile

--- a/.github/workflows/dialog.yml
+++ b/.github/workflows/dialog.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   turkeyGitops:
-    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@master
+    uses: Hubs-Foudation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
-      registry: mozillareality
+      registry: Hubs-Foundation
       dockerfile: Dockerfile
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 
-.github/workflows   @mozilla/xr
+.github/workflows   @Hubs-Foundation

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 
-.github/workflows   @Hubs-Foundation
+.github/workflows   @Hubs-Foundation/operations 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Mediasoup based WebRTC SFU for Hubs.
 1. Clone repo
 2. In root project folder, `npm ci` (this may take a while).
 3. Create a folder in the root project folder called `certs` if needed (see steps 4 & 5).
-4. Add the ssl cert and key to the `certs` folder as `fullchain.pem` and `privkey.pem`, or set the path to these in your shell via `HTTPS_CERT_FULLCHAIN` and `HTTPS_CERT_PRIVKEY` respectively. You can provide these certs yourself or use the ones available in https://github.com/mozilla/reticulum/tree/master/priv (`dev-ssl.cert` and `dev-ssl.key`).
+4. Add the ssl cert and key to the `certs` folder as `fullchain.pem` and `privkey.pem`, or set the path to these in your shell via `HTTPS_CERT_FULLCHAIN` and `HTTPS_CERT_PRIVKEY` respectively. You can provide these certs yourself or use the ones available in https://github.com/Hubs-Foundation/reticulum/tree/master/priv (`dev-ssl.cert` and `dev-ssl.key`).
 
 5. Add the reticulum permissions public key to the `certs` folder as `perms.pub.pem`, or set the path to the file in your shell via `AUTH_KEY`.
 
-  * If using one of the public keys from hubs-ops (located in https://github.com/mozilla/hubs-ops/tree/master/ansible/roles/janus/files), you will need to convert it to standard pem format.    
+  * If using one of the public keys from hubs-ops (located in https://github.com/Hubs-Foundation/hubs-ops/tree/master/ansible/roles/janus/files), you will need to convert it to standard pem format.    
     * e.g. for use with dev.reticulum.io:  `openssl rsa -in perms.pub.der.dev -inform DER -RSAPublicKey_in -out perms.pub.pem`
 
 6. Start dialog with `MEDIASOUP_LISTEN_IP=XXX.XXX.XXX.XXX MEDIASOUP_ANNOUNCED_IP=XXX.XXX.XXX.XXX npm start` where `XXX.XXX.XXX.XXX` is the local IP address of the machine running the server. (In the case of a VM, this should be the internal IP address of the VM).

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,6 +1,6 @@
 pkg_name=janus-gateway
-pkg_origin=mozillareality
-pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
+pkg_origin=Hubs-Foundation
+pkg_maintainer="Hubs Foundation <info@hubsfoundation.org>"
 pkg_version="2.0.1"
 pkg_description="A simple mediasoup based SFU"
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "dialog",
   "version": "0.0.1",
   "description": "WebRTC SFU based on mediasoup",
-  "author": "Mozilla Mixed Reality <mixreality@mozilla.com>",
+  "author": "Hubs Foundation <info@hubsfoundation.org>",
   "license": "MPL-2.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- For Github-Actions (.github/workflows/dialog.yml) I've changed the registry to "Hubs-Foundation", even though this account seemingly does not exist (yet?)
- Codeowners: Just referenced the org here, without referencing any team
- As for Habitat (habitat/plan.sh): I changed origin and maintainer. But it does have dependencies to Mozilla packages. Is Habitat even still relevant for us?