### PR TITLE
[Mozilla Branding Removal] Replaces Mozilla branding with Hubs Foundation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+
+.github         @hubsfoundation/Operations

--- a/.github/workflows/dialog.yml
+++ b/.github/workflows/dialog.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   turkeyGitops:
-    uses: mozilla/hubs-ops/.github/workflows/turkeyGitops.yml@master
+    uses: Hubs-Foundation/hubs-ops/.github/workflows/turkeyGitops.yml@master
     with:
-      registry: mozillareality
+      registry: hubsfoundation
       dockerfile: Dockerfile
     secrets:
       DOCKER_HUB_PWD: ${{ secrets.DOCKER_HUB_PWD }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-
-.github/workflows   @mozilla/xr

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Mediasoup based WebRTC SFU for Hubs.
 1. Clone repo
 2. In root project folder, `npm ci` (this may take a while).
 3. Create a folder in the root project folder called `certs` if needed (see steps 4 & 5).
-4. Add the ssl cert and key to the `certs` folder as `fullchain.pem` and `privkey.pem`, or set the path to these in your shell via `HTTPS_CERT_FULLCHAIN` and `HTTPS_CERT_PRIVKEY` respectively. You can provide these certs yourself or use the ones available in https://github.com/mozilla/reticulum/tree/master/priv (`dev-ssl.cert` and `dev-ssl.key`).
+4. Add the ssl cert and key to the `certs` folder as `fullchain.pem` and `privkey.pem`, or set the path to these in your shell via `HTTPS_CERT_FULLCHAIN` and `HTTPS_CERT_PRIVKEY` respectively. You can provide these certs yourself or use the ones available in https://github.com/Hubs-Foundatioin/reticulum/tree/master/priv (`dev-ssl.cert` and `dev-ssl.key`).
 
 5. Add the reticulum permissions public key to the `certs` folder as `perms.pub.pem`, or set the path to the file in your shell via `AUTH_KEY`.
 
-  * If using one of the public keys from hubs-ops (located in https://github.com/mozilla/hubs-ops/tree/master/ansible/roles/janus/files), you will need to convert it to standard pem format.    
+  * If using one of the public keys from hubs-ops (located in https://github.com/Hubs-Foundation/hubs-ops/tree/master/ansible/roles/janus/files), you will need to convert it to standard pem format.
     * e.g. for use with dev.reticulum.io:  `openssl rsa -in perms.pub.der.dev -inform DER -RSAPublicKey_in -out perms.pub.pem`
 
 6. Start dialog with `MEDIASOUP_LISTEN_IP=XXX.XXX.XXX.XXX MEDIASOUP_ANNOUNCED_IP=XXX.XXX.XXX.XXX npm start` where `XXX.XXX.XXX.XXX` is the local IP address of the machine running the server. (In the case of a VM, this should be the internal IP address of the VM).

--- a/habitat/plan.sh
+++ b/habitat/plan.sh
@@ -1,18 +1,18 @@
 pkg_name=janus-gateway
-pkg_origin=mozillareality
-pkg_maintainer="Mozilla Mixed Reality <mixreality@mozilla.com>"
+pkg_origin=hubsfoundation
+pkg_maintainer="Hubs Foundation <info@hubsfoundation.org>"
 pkg_version="2.0.1"
 pkg_description="A simple mediasoup based SFU"
 
 pkg_deps=(
   core/node/18
-  mozillareality/gcc-libs
-  mozillareality/openssl
+  hubsfoundation/gcc-libs
+  hubsfoundation/openssl
 )
 
 pkg_build_deps=(
   core/git
-  mozillareality/gcc
+  hubsfoundation/gcc
   core/make
   core/patchelf
 )

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "dialog",
   "version": "0.0.1",
   "description": "WebRTC SFU based on mediasoup",
-  "author": "Mozilla Mixed Reality <mixreality@mozilla.com>",
+  "author": "Hubs Foundation <info@hubsfoundation.org> (https://hubsfoundation.org)",
+  "contributors": ["Mozilla Mixed Reality [original author]"],
   "license": "MPL-2.0",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## What?
1. Replaces Mozilla branding with Hubs Foundation

## Why?
1. to make clear who's responsible

## How to test
1. Install in Hubs instance:
    1. Run `kubectl set image deployment/dialog dialog=dougreeder/dialog:mozilla-branding-removal-2026-01-28-04-04 -n hcce`
    2. Run `kubectl rollout status deploy dialog -n hcce`
2. Navigate to instance, verify that voice chat still works
3. Run `kubectl top pod -n hcce`, verify that memory usage is less than 160MiB.

## Documentation of functionality
No changes to functionality

## Limitations
Node v24 (the LTS version) and v22 have errors when building image
